### PR TITLE
Fix fetch withdrawals and deposits methods

### DIFF
--- a/js/cobinhood.js
+++ b/js/cobinhood.js
@@ -536,11 +536,10 @@ module.exports = class cobinhood extends Exchange {
         }
         let curr = this.currency (currency);
         let request = {
-            'limit': limit,
             'currency': curr['id'],
         };
         let response = await this.privateGetWalletDeposits (this.extend (request, params));
-        return this.parseTransactions (response['result']['deposits'], 'deposit');
+        return this.parseTransactions (response['result']['deposits'], 'deposit', undefined, limit);
     }
 
     async fetchWithdrawals (currency = undefined, since = undefined, limit = undefined, params = {}) {
@@ -550,11 +549,10 @@ module.exports = class cobinhood extends Exchange {
         }
         let curr = this.currency (currency);
         let request = {
-            'limit': limit,
             'currency': curr['id'],
         };
         let response = await this.privateGetWalletWithdrawals (this.extend (request, params));
-        return this.parseTransactions (response['result']['withdrawals'], 'withdraw');
+        return this.parseTransactions (response['result']['withdrawals'], 'withdraw', undefined, limit);
     }
 
     parseTransactionStatus (status) {
@@ -593,7 +591,6 @@ module.exports = class cobinhood extends Exchange {
             'currency': currency,
             'status': this.parseTransactionStatus (transaction['status']),
             'side': side, // direction of the transaction, ('deposit' | 'withdraw')
-            'price': undefined,
             'amount': this.safeFloat (transaction, 'amount'),
             'fee': {
                 'cost': this.safeFloat (transaction, 'fee'),


### PR DESCRIPTION
`limit` is not a valid parameter in the request, but can be used in the parseTransactions method.
`price` was removed as per discussion in #1896 and #2355.