### PR TITLE
Removing verbose print

### DIFF
--- a/python/ccxt/async_support/base/exchange.py
+++ b/python/ccxt/async_support/base/exchange.py
@@ -680,7 +680,6 @@ class Exchange(BaseExchange, EventEmitter):
             self.websocketDelayedConnections = {}
 
     async def websocket_connect(self, conxid='default'):
-        print("connecting conxid:" + conxid)
         sys.stdout.flush()
         websocket_conx_info = self._contextGetConnectionInfo(conxid)
         conx_tpl = self._contextGetConxTpl(conxid)


### PR DESCRIPTION
Suggesting to remove redundant print on websocket connections. Too verbose when doing multiple subscriptions.