### PR TITLE
modify ws-example.py config: add 'verbose': True

### DIFF
--- a/examples/py/ws-example.py
+++ b/examples/py/ws-example.py
@@ -12,7 +12,8 @@ loop = asyncio.get_event_loop()  # type: asyncio.BaseEventLoop
 
 async def main():
     ws = WebsocketConnection({
-        'url': 'wss://echo.websocket.org'
+        'url': 'wss://echo.websocket.org',
+        'verbose': True,
     }, 5 * 1000, loop)
 
     @ws.on('err')


### PR DESCRIPTION
The config dict passed to the python WebsocketConnection constructor
now requires a 'verbose' key. This commit adds the entry
`'verbose': True` to the config dict that is passed to the
WebsocketConnection constructor in the examples/py/ws-example.py file,
eliminating a 'KeyError' exception that was being thrown by the
call to ws.connect() in that file.